### PR TITLE
Split stats into new_downloads and updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,13 @@ deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN
         file:
-          - daily.json
-          - weekly.json
-          - monthly.json
-          - yearly.json
+          - daily_new_downloads.json
+          - weekly_new_downloads.json
+          - monthly_new_downloads.json
+          - yearly_new_downloads.json
+          - daily_updates.json
+          - weekly_updates.json
+          - monthly_updates.json
+          - yearly_updates.json
         overwrite: true
         skip_cleanup: true


### PR DESCRIPTION
As far as I can see at https://github.com/flathub/flathub-stats/blob/master/update-stats.py#L27-L31 the first item in download stats is a `downloads + updates` count, and the second one is `updates` count.

The current `flathub-app-stats` sums every number, thus resulting in `downloads + 2*updates` counted.

My patch splits the results into `{daily,weekly,yearly}_updates.json` and `{daily,weekly,yearly}_new_downloads.json` files.

I hope this change is useful. :)

Example results (for `com.valvesoftware.Steam`):
```
daily_new_downloads.json:  "com.valvesoftware.Steam": 244,
daily_updates.json:  "com.valvesoftware.Steam": 1670,
weekly_new_downloads.json:  "com.valvesoftware.Steam": 1557,
weekly_updates.json:  "com.valvesoftware.Steam": 8939,
monthly_new_downloads.json:  "com.valvesoftware.Steam": 15757,
monthly_updates.json:  "com.valvesoftware.Steam": 42894,
yearly_new_downloads.json:  "com.valvesoftware.Steam": 35136,
yearly_updates.json:  "com.valvesoftware.Steam": 73424,
```

as compared to
```
daily.json:  "com.valvesoftware.Steam": 3584,
weekly.json:  "com.valvesoftware.Steam": 19435,
monthly.json:  "com.valvesoftware.Steam": 101545,
yearly.json:  "com.valvesoftware.Steam": 181984,
```
– as you can see, `new_downloads + 2*updates = old_result`.